### PR TITLE
feat(main): 함예정 과제 제출 / API 요청으로 메시지 전송 추가

### DIFF
--- a/src/main/java/com/inspire12/likelionwebsocket/config/WebSocketConfig.java
+++ b/src/main/java/com/inspire12/likelionwebsocket/config/WebSocketConfig.java
@@ -1,9 +1,7 @@
 package com.inspire12.likelionwebsocket.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.inspire12.likelionwebsocket.service.ChatWebSocketHandler;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.*;
 

--- a/src/main/java/com/inspire12/likelionwebsocket/config/WebSocketConfig.java
+++ b/src/main/java/com/inspire12/likelionwebsocket/config/WebSocketConfig.java
@@ -3,6 +3,7 @@ package com.inspire12.likelionwebsocket.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.inspire12.likelionwebsocket.service.ChatWebSocketHandler;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.*;
 
@@ -11,11 +12,11 @@ import org.springframework.web.socket.config.annotation.*;
 @EnableWebSocket
 public class WebSocketConfig implements WebSocketConfigurer {
 
-    private final ObjectMapper mapper;
+    private final ChatWebSocketHandler chatWebSocketHandler;
 
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-        registry.addHandler(new ChatWebSocketHandler(mapper),  "/ws")
+        registry.addHandler(chatWebSocketHandler,  "/ws")
 //                .setAllowedOrigins("http://localhost:3000");
                 .setAllowedOrigins("*");
     }

--- a/src/main/java/com/inspire12/likelionwebsocket/controller/MessageController.java
+++ b/src/main/java/com/inspire12/likelionwebsocket/controller/MessageController.java
@@ -1,0 +1,24 @@
+package com.inspire12.likelionwebsocket.controller;
+
+import com.inspire12.likelionwebsocket.model.ChatMessage;
+import com.inspire12.likelionwebsocket.model.ServerMessage;
+import com.inspire12.likelionwebsocket.service.ChatWebSocketHandler;
+import com.inspire12.likelionwebsocket.service.MessageService;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MessageController {
+    private final ChatWebSocketHandler handler;
+    private final MessageService messageService;
+
+    @PostMapping("/call")
+    public ChatMessage call(@RequestBody ServerMessage serverMessage) throws Exception {
+        return messageService.sendServerMessage(serverMessage);
+    }
+}

--- a/src/main/java/com/inspire12/likelionwebsocket/controller/MessageController.java
+++ b/src/main/java/com/inspire12/likelionwebsocket/controller/MessageController.java
@@ -2,11 +2,8 @@ package com.inspire12.likelionwebsocket.controller;
 
 import com.inspire12.likelionwebsocket.model.ChatMessage;
 import com.inspire12.likelionwebsocket.model.ServerMessage;
-import com.inspire12.likelionwebsocket.service.ChatWebSocketHandler;
 import com.inspire12.likelionwebsocket.service.MessageService;
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -14,7 +11,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 public class MessageController {
-    private final ChatWebSocketHandler handler;
     private final MessageService messageService;
 
     @PostMapping("/call")

--- a/src/main/java/com/inspire12/likelionwebsocket/model/ChatMessage.java
+++ b/src/main/java/com/inspire12/likelionwebsocket/model/ChatMessage.java
@@ -33,4 +33,12 @@ public class ChatMessage {
 
         return welcomeMessage;
     }
+
+    public static ChatMessage createServerMessage(String message){
+        return ChatMessage.builder()
+                          .sender("System")
+                          .content(message)
+                          .type(MessageType.CHAT)
+                          .build();
+    }
 }

--- a/src/main/java/com/inspire12/likelionwebsocket/model/ServerMessage.java
+++ b/src/main/java/com/inspire12/likelionwebsocket/model/ServerMessage.java
@@ -1,0 +1,8 @@
+package com.inspire12.likelionwebsocket.model;
+
+import lombok.Getter;
+
+@Getter
+public class ServerMessage {
+    private String message;
+}

--- a/src/main/java/com/inspire12/likelionwebsocket/service/ChatWebSocketHandler.java
+++ b/src/main/java/com/inspire12/likelionwebsocket/service/ChatWebSocketHandler.java
@@ -1,20 +1,24 @@
 package com.inspire12.likelionwebsocket.service;
 
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.inspire12.likelionwebsocket.model.ChatMessage;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.PongMessage;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
+import org.w3c.dom.Text;
 
 import java.security.Principal;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
+@Component
 public class ChatWebSocketHandler extends TextWebSocketHandler {
     // 연결된 모든 세션을 저장할 스레드 안전한 Set
     private final Set<WebSocketSession> sessions = new CopyOnWriteArraySet<>();
@@ -33,12 +37,20 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
     protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
         // 수신한 메시지를 모든 세션에 브로드캐스트
         ChatMessage chatMessage = objectMapper.readValue(message.getPayload(), ChatMessage.class);
-        TextMessage messageToSend = message;
         if (chatMessage.getType() == ChatMessage.MessageType.JOIN) {
-            ChatMessage welcomeMessage = ChatMessage.createWelcomeMessage(chatMessage.getSender());
-            messageToSend = new TextMessage(objectMapper.writeValueAsBytes(welcomeMessage));
+            chatMessage = ChatMessage.createWelcomeMessage(chatMessage.getSender());
         }
 
+        sendBoradcastMessage(chatMessage);
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+        sessions.remove(session);
+    }
+
+    public void sendBoradcastMessage(ChatMessage chatMessage) throws Exception {
+        TextMessage messageToSend = toTextMessage(chatMessage);
         for (WebSocketSession webSocketSession : sessions) {
             if (webSocketSession.isOpen()) {
                 webSocketSession.sendMessage(messageToSend);
@@ -46,9 +58,8 @@ public class ChatWebSocketHandler extends TextWebSocketHandler {
         }
     }
 
-    @Override
-    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
-        sessions.remove(session);
+    private TextMessage toTextMessage(Object messageObject) throws JsonProcessingException {
+        return new TextMessage(objectMapper.writeValueAsBytes(messageObject));
     }
 }
 

--- a/src/main/java/com/inspire12/likelionwebsocket/service/MessageService.java
+++ b/src/main/java/com/inspire12/likelionwebsocket/service/MessageService.java
@@ -1,11 +1,20 @@
 package com.inspire12.likelionwebsocket.service;
 
 import com.inspire12.likelionwebsocket.model.ChatMessage;
+import com.inspire12.likelionwebsocket.model.ServerMessage;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class MessageService {
+    private final ChatWebSocketHandler chatWebSocketHandler;
 
+    public ChatMessage sendServerMessage(ServerMessage serverMessage) throws Exception {
+        ChatMessage messageToSend = ChatMessage.createServerMessage(serverMessage.getMessage());
+        chatWebSocketHandler.sendBoradcastMessage(messageToSend);
+        return messageToSend;
+    }
     public ChatMessage createWelcomeMessage(ChatMessage chatMessage) {
         return ChatMessage.createWelcomeMessage(chatMessage.getSender());
     }


### PR DESCRIPTION
## **Created**

#### `model/ServerMessage`
- 서버 전송 메시지 클래스 생성

#### `controller/MessageController`
- API 요청을 받기 위한 컨트롤러 클래스 생성

---

## **Modified**
#### `model/ChatMessage`
- sendServerMessage 메소드 추가

#### `service/MessageService`
- sendServerMessage 메소드 추가

#### `service/ChatWebSocketHandler`
- Spring Bean으로 등록하여, 다른 클래스에서 사용 가능하도록 수정  
- sendBoradcastMessage 메소드 추가: 코드 재사용성 고려  
- toTextMessage 메소드 추가: 코드 가독성 향상

#### `config/WebSocketConfig`
- 웹소켓 핸들러 Spring Bean으로 바꾸며 수정

![result1](https://github.com/user-attachments/assets/fc4e1938-b2d7-4557-8aea-c3c1b4daf630)
![result2](https://github.com/user-attachments/assets/7b03154d-0c49-495c-b7cd-48d16311c335)
